### PR TITLE
Add equation tests

### DIFF
--- a/test_scan_funcs.py
+++ b/test_scan_funcs.py
@@ -1,10 +1,11 @@
 import numpy as np
 import time
-import einops
 import math
 from functools import partial
-import jax
-import jax.numpy as jnp
+import pytest
+einops = pytest.importorskip('einops')
+jax = pytest.importorskip('jax')
+jnp = pytest.importorskip('jax.numpy')
 from jax import custom_vjp, jit
 from jax.experimental.jet import jet
 from jax import config

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -1,0 +1,49 @@
+import inspect
+import pytest
+
+jax = pytest.importorskip('jax')
+jnp = pytest.importorskip('jax.numpy')
+hk = pytest.importorskip('haiku')
+# The equations module requires folx via stde.operators. Skip tests if folx
+# cannot be imported (e.g. due to missing jaxlib support).
+pytest.importorskip('folx')
+
+from stde.config import EqnConfig
+from stde.types import Equation
+import stde.equations as equations
+
+# Collect all Equation objects defined in equations.py
+EQUATION_NAMES = [name for name, val in inspect.getmembers(equations)
+                  if isinstance(val, Equation)]
+
+@pytest.mark.parametrize('name', EQUATION_NAMES)
+def test_equation_forms(name):
+    eqn: Equation = getattr(equations, name)
+    cfg = EqnConfig(dim=2)
+
+    if getattr(eqn, 'random_coeff', False):
+        cfg.coeffs = jnp.ones((1, cfg.dim))
+
+    sample_fn = eqn.get_sample_domain_fn(cfg)
+    x, t, xb, tb, _ = sample_fn(2, 2, jax.random.PRNGKey(0))
+
+    # Shapes of sampled points
+    assert x.shape[0] == 2
+    if t is not None:
+        assert t.shape[0] == 2
+
+    # Solution and boundary condition should produce outputs matching batch size
+    u_val = eqn.sol(x, t, cfg)
+    assert u_val.shape[0] == x.shape[0]
+
+    g_val = eqn.boundary_cond(xb, tb, cfg)
+    assert g_val.shape[0] == xb.shape[0]
+
+    enforced = eqn.enforce_boundary(xb, tb, g_val, cfg)
+    assert enforced.shape == g_val.shape
+
+    # Residual should vanish for the analytical solution if defined on the domain
+    if not getattr(eqn, 'is_traj', False):
+        u_fn = lambda x_, t_: eqn.sol(x_[None], t_ if t_ is None else t_[None], cfg)
+        res = eqn.res(x[0], None if t is None else t[0], u_fn, cfg)
+        assert jnp.allclose(res, 0.0, atol=1e-4)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -3,6 +3,7 @@ import pytest
 jax = pytest.importorskip('jax')
 jnp = pytest.importorskip('jax.numpy')
 hk = pytest.importorskip('haiku')
+pytest.importorskip('folx')
 
 from stde.config import EqnConfig
 from stde.operators import get_hutchinson_random_vec, get_sdgd_idx_set


### PR DESCRIPTION
## Summary
- add pytest for `stde.equations` objects
- guard dependency heavy tests with `importorskip`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684703072a7483209669f0006a671999