### PR TITLE
Use hess_diag Laplacian estimator

### DIFF
--- a/train_bimamba_sine_gordon.py
+++ b/train_bimamba_sine_gordon.py
@@ -34,7 +34,7 @@ from stde.equations import (
     threebody_sol as eq_threebody_sol,
     SineGordon_threebody_inhomo_exact,
 )
-from stde.operators import hte
+from stde.operators import hess_diag
 # -----------------------------------------------------------------------------
 # CLI arguments
 # -----------------------------------------------------------------------------
@@ -232,12 +232,13 @@ def sample_domain_fn(batch_size: int,
 # STDE using utilities from stde.operators
 
 def hess_trace(fn: Callable, cfg: EqnConfig) -> Callable:
-    """Return a Hessian-trace estimator for ``fn`` using :func:`hte`."""
+    """Return a Laplacian estimator for ``fn`` using :func:`hess_diag`."""
 
-    ht = hte(fn, cfg, argnums=0)
+    hd = hess_diag(fn, cfg, argnums=0, with_time=False)
 
     def fn_trace(x_i):
-        _, f_val, trace_est = ht(x_i)
+        _, f_val, _, hess_diag_val = hd(x_i)
+        trace_est = jnp.sum(hess_diag_val)
         return f_val, trace_est
 
     return fn_trace


### PR DESCRIPTION
## Summary
- update the training script to rely on `stde.operators.hess_diag`
- compute Laplacian from the Hessian diagonal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jaxlib.xla_extension')*

------
https://chatgpt.com/codex/tasks/task_e_684ae5d6b2dc8320a79767570f66ec10