### PR TITLE
Enable PDE selection in BiMamba example

### DIFF
--- a/train_bimamba_sine_gordon.py
+++ b/train_bimamba_sine_gordon.py
@@ -3,7 +3,7 @@ import argparse
 import os
 import json
 from functools import partial
-from typing import Callable, Tuple, Optional
+from typing import Callable, Tuple, Optional, get_args
 
 import haiku as hk
 import jax
@@ -28,14 +28,8 @@ from pprint import pprint
 
 from my_mamba import BidirectionalMamba, MambaConfig, DiagnosticsConfig, SSMConfig
 from stde.config import EqnConfig
-from stde.equations import (
-    twobody_sol as eq_twobody_sol,
-    SineGordon_twobody_inhomo_exact,
-    threebody_sol as eq_threebody_sol,
-    SineGordon_threebody_inhomo_exact,
-)
+from stde import equations as eqns
 
-from stde.operators import hess_diag
 
 # -----------------------------------------------------------------------------
 # CLI arguments
@@ -51,7 +45,6 @@ parser.add_argument("--lr", type=float, default=1e-3)
 parser.add_argument("--N_test", type=int, default=2000)
 parser.add_argument("--test_batch_size", type=int, default=20)
 parser.add_argument("--seq_len", type=int, default=3, help="sequence length for Bi-MAMBA")
-parser.add_argument("--rand_batch_size", type=int, default=16)
 parser.add_argument("--x_radius", type=float, default=1.0)
 parser.add_argument("--x_ordering", type=str, choices=["none", "coordinate", "radial"], default="radial", help="How to order your spatial sequence: `none` (leave random), `coordinate` (sort by x[0]), `radial` (sort by ∥x∥).")
 
@@ -84,12 +77,13 @@ parser.add_argument(
     default="rademacher",
     help="distribution for dense STDE",
 )
+eqn_choices = get_args(EqnConfig.__annotations__["name"])
 parser.add_argument(
-    "--problem",
+    "--eqn_name",
     type=str,
-    choices=["twobody", "threebody"],
-    default="twobody",
-    help="choose sine-gordon variant",
+    choices=eqn_choices,
+    default="SineGordonTwobody",
+    help="PDE to solve",
 )
 
 # numberof bidirectional mamba blocks
@@ -124,6 +118,11 @@ parser.add_argument("--ssm_activation", type=str, default="silu", choices=["silu
 parser.add_argument("--run_name", type=str, default="test_run")
 
 args = parser.parse_args()
+
+# derive rand_batch_size from dimension (order of magnitude lower)
+rand_batch_size = max(2, args.dim // 10)
+args.rand_batch_size = rand_batch_size
+
 pprint(args)
 
 # set up Haiku PRNG sequence for stde.operators
@@ -231,55 +230,34 @@ def sample_domain_fn(batch_size: int,
 # Hessian‐trace estimator
 # -----------------------------------------------------------------------------
 
-# STDE using utilities from stde.operators
-
-def hess_trace(fn: Callable, cfg: EqnConfig) -> Callable:
-    """Return a Laplacian estimator for ``fn`` using :func:`hess_diag`."""
-
-    hd = hess_diag(fn, cfg, argnums=0, with_time=False)
-
-    def fn_trace(x_i):
-        _, f_val, _, hess_diag_val = hd(x_i)
-        trace_est = jnp.sum(hess_diag_val)
-        return f_val, trace_est
-
-    return fn_trace
-
-def SineGordon_op(x, u_fn: Callable) -> Float[Array, "xt_dim"]:
-    r"""
-    .. math::
-    \nabla u(x) + sin(u(x)) = g(x)
-    """
-    # run the Hessian‐trace estimator
-    u_, lap = hess_trace(u_fn, eqn_cfg)(x)
-    return lap + jnp.sin(u_)
-
 
 coeffs_ = np.random.randn(1, args.dim)
 
 eqn_cfg = EqnConfig(
+    name=args.eqn_name,
     dim=args.dim,
     max_radius=args.x_radius,
-    rand_batch_size=args.rand_batch_size,
+    rand_batch_size=rand_batch_size,
     hess_diag_method=args.hess_diag_method,
     stde_dist=args.stde_dist,
 )
-eqn_cfg.coeffs = coeffs_
-if args.problem == "twobody":
-    sol_fn = lambda x: eq_twobody_sol(x, None, eqn_cfg)
-    g_exact_fn = lambda x: SineGordon_twobody_inhomo_exact(x, eqn_cfg)
-else:
-    sol_fn = lambda x: eq_threebody_sol(x, None, eqn_cfg)
-    g_exact_fn = lambda x: SineGordon_threebody_inhomo_exact(x, eqn_cfg)
 
-def SineGordon_res_fn(x, u_fn: Callable) -> Float[Array, "xt_dim"]:
-    r"""
-    .. math::
-    L u(x) = g(x)
-    """
-    Lu = SineGordon_op(x, u_fn)
-    g = g_exact_fn(x)
-    return Lu - g
+eqn = getattr(eqns, eqn_cfg.name)
+if eqn.random_coeff:
+    eqn_cfg.coeffs = coeffs_
+else:
+    eqn_cfg.coeffs = None
+
+if eqn.time_dependent:
+    raise NotImplementedError("Time-dependent PDEs are not supported")
+
+sol_fn = lambda x: eqn.sol(x, None, eqn_cfg)
+
+def residual_fn(x, u_fn: Callable) -> Float[Array, "xt_dim"]:
+    res = eqn.res(x, None, lambda xi, _t: u_fn(xi), eqn_cfg)
+    if isinstance(res, tuple):
+        res = res[0]
+    return res
 
 # -----------------------------------------------------------------------------
 # Training state
@@ -465,7 +443,7 @@ def main():
         # 1) split off one rng for sampling, one to carry forward
         batch_rng, next_rng = jax.random.split(state.rng)
         x_seq, batch_rng = sample_domain_fn(
-            batch_size=args.rand_batch_size,
+            batch_size=rand_batch_size,
             rng=batch_rng,
             radius=args.x_radius,
             dim=args.dim,
@@ -487,7 +465,7 @@ def main():
 
             # 2) sample a fresh batch of input sequences
             x_seq, batch_rng = sample_domain_fn(
-                batch_size=args.rand_batch_size,
+                batch_size=rand_batch_size,
                 rng=batch_rng,
                 radius=args.x_radius,
                 dim=args.dim,
@@ -514,13 +492,8 @@ def main():
                     def u_fn(xi):
                         return y_at_l(xi, l, full_seq)
 
-                    # STDE Hessian-trace at x_l
-                    y0, lap = hess_trace(u_fn, eqn_cfg)(x_l)
-
-                    # analytic inhomogeneity
-                    g0 = g_exact_fn(x_l)
-
-                    return (lap + jnp.sin(y0) - g0), key
+                    res_val = residual_fn(x_l, u_fn)
+                    return res_val, key
 
                 # split into L subkeys, run across time steps
                 keys = jax.random.split(key, L)


### PR DESCRIPTION
## Summary
- support choosing any equation from `EqnConfig` when running the BiMAMBA trainer
- derive `rand_batch_size` from `dim` rather than exposing a CLI flag
- remove hard coded Sine-Gordon routines and rely on `stde.equations`
- fix residual wrapper so it accepts both `x` and `t` arguments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jaxlib.xla_extension')*

------
https://chatgpt.com/codex/tasks/task_e_684b1e7ba1988320bb402a8f232658d5