### PR TITLE
Fix Threebody dimension handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ For reader who do not wish to go through the entire repo, the script `sine_gordo
 python sine_gordon.py --sparse --dim 100000 --rand_batch_size 16
 ```
 
+> **Note**
+> Some "threebody" equations (e.g. `SineGordonThreebody`) require a spatial
+> dimension of at least 3. Running them with `--dim < 3` will produce invalid
+> reference solutions and lead to infinite relative errors.
+
 # How to reproduce results shown in the paper
 ## Inseparable and effectively high-dimensional PDEs
 To run the 100kD two-body Allen-Cahn equation described in Appendix I.1. with sparse STDE: 

--- a/stde/equations.py
+++ b/stde/equations.py
@@ -620,6 +620,8 @@ def threebody_sol(
   t: types.T,
   cfg: EqnConfig,
 ) -> Float[types.NPArray, "*batch"]:
+  if cfg.dim < 3:
+    raise ValueError("Threebody equations require dim >= 3")
   t1 = cfg.max_radius**2 - jnp.sum(x**2, -1)
   x1, x2, x3 = x[..., :-2], x[..., 1:-1], x[..., 2:]
   t2 = cfg.coeffs[:, :-2] * jnp.exp(x1 * x2 * x3)
@@ -629,6 +631,8 @@ def threebody_sol(
 
 
 def threebody_lapl_analytical(x: types.x_like, cfg: EqnConfig):
+  if cfg.dim < 3:
+    raise ValueError("Threebody equations require dim >= 3")
   coeffs = cfg.coeffs[:, :-2]
   u1 = cfg.max_radius**2 - jnp.sum(x**2)
   du1_dx = -2 * x

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -18,7 +18,8 @@ EQUATION_NAMES = [name for name, val in inspect.getmembers(equations)
 @pytest.mark.parametrize('name', EQUATION_NAMES)
 def test_equation_forms(name):
     eqn: Equation = getattr(equations, name)
-    cfg = EqnConfig(dim=2)
+    dim = 3 if 'Threebody' in name else 2
+    cfg = EqnConfig(dim=dim)
 
     if getattr(eqn, 'random_coeff', False):
         cfg.coeffs = jnp.ones((1, cfg.dim))

--- a/train_bimamba.py
+++ b/train_bimamba.py
@@ -160,6 +160,9 @@ args = parser.parse_args()
 rand_batch_size = max(1, args.dim // 10)
 args.rand_batch_size = rand_batch_size
 
+if "Threebody" in args.eqn_name and args.dim < 3:
+    raise ValueError("Threebody equations require --dim >= 3")
+
 pprint(args)
 
 # set up Haiku PRNG sequence for stde.operators


### PR DESCRIPTION
## Summary
- warn users that threebody PDEs require dimension >=3
- error if threebody equations are run with too few dimensions
- update tests to use `dim=3` for threebody equations
- validate dimension in `train_bimamba.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jaxlib.xla_extension')*

------
https://chatgpt.com/codex/tasks/task_e_684c911dccfc8320b0f78c394c66702d