### PR TITLE
Add Burgers equation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ information relevant to the implementation.
 | `HJB_LIN` | ✓ | ✗ | \(u_t + \Delta u - d^{-1}\|\nabla u\|^c = -2\) | \(u(x,T)=\sum_i x_i\) |
 | `HJB_LQG` | ✓ | ✗ | \(u_t + \Delta u - \mu\|\nabla u\|^2 = 0\) | \(u(x,T)=\log((1+\|x\|^2)/2)\) |
 | `BSB` | ✓ | ✗ | \(u_t + \tfrac{1}{2}\sigma^2 x^2\cdot\nabla^2 u - r(u- x\cdot\nabla u)=0\) | \(u(x,T)=\sum_i x_i^2\) |
+| `Burgers` | ✓ | ✗ | \(u_t + u\,u_x = \sigma\,u_{xx}\) | \(u(x,0)=-\tanh(x/(2\sigma))\) |
 | `Wave` | ✓ | ✗ | \(u_{tt}-\Delta u=0\) | \(u(x,0)=\sum_i\sinh x_i,\ u_t(x,0)=0\) |
 | `Poisson` | ✗ | ✗ | \(\Delta u = g(x)\) | \(u(x)=\sum_i e^{x_i}/d\) |
 | `PoissonHouman` | ✗ | ✗ | \(\Delta u = g(x)\) | same as `Poisson` |

--- a/stde/config.py
+++ b/stde/config.py
@@ -20,6 +20,7 @@ class EqnConfig:
     # "BSB",
     "Wave",
     "Poisson",
+    "Burgers",
     # "PoissonHouman",
     # "PoissonTwobody",
     # "PoissonTwobodyG",

--- a/stde/equations.py
+++ b/stde/equations.py
@@ -535,6 +535,59 @@ Poisson: Equation = Equation(
 )
 
 
+def Burgers_res(
+  x: types.x_like,
+  t: types.t_like,
+  u: types.U,
+  cfg: EqnConfig,
+) -> Float[Array, "1"]:
+  """Residual for the 1D viscous Burgers' equation."""
+  xt = jnp.concatenate([x, t], axis=-1)
+
+  def u_xt(xt):
+    x_ = xt[: cfg.dim]
+    t_ = xt[cfg.dim :]
+    return jnp.squeeze(u(x_, t_))
+
+  _, u_val, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt)
+  u_x = u_d1[:-1]
+  u_t = u_d1[-1:]
+  u_xx = u_d2[:-1]
+
+  res = u_t + u_val * u_x - cfg.sigma * u_xx.sum()
+  return jnp.squeeze(res)
+
+
+def Burgers_sol(x: types.X, t: types.T, cfg: EqnConfig) -> Float[types.NPArray, "*batch"]:
+  return -jnp.tanh(x / (2 * cfg.sigma))
+
+
+def Burgers_boundary_cond(x: types.X, t: types.T, cfg: EqnConfig) -> Float[types.NPArray, "*batch"]:
+  return Burgers_sol(x, t, cfg)
+
+
+def Burgers_get_sample_domain_fn(cfg: EqnConfig) -> Callable:
+  @partial(jax.jit, static_argnames=["n_pts", "n_pts_boundary"])
+  def sample_domain(n_pts: int, n_pts_boundary: int, rng: jax.Array):
+    keys = jax.random.split(rng, 4)
+    x = jax.random.normal(keys[0], (n_pts, cfg.dim))
+    t = jax.random.uniform(keys[1], (n_pts, 1)) * cfg.T
+    x_boundary = jax.random.normal(keys[2], (n_pts_boundary, cfg.dim))
+    t_boundary = jnp.zeros((n_pts_boundary, 1))
+    return x, t, x_boundary, t_boundary, keys[3]
+
+  return sample_domain
+
+
+Burgers: Equation = Equation(
+  Burgers_res,
+  Burgers_boundary_cond,
+  identity_fn,
+  Burgers_sol,
+  Burgers_get_sample_domain_fn,
+)
+
+
 def ZeroOnUnitBall_enforce_boundary(
   x: types.X,
   t: types.T,

--- a/tests/test_burgers.py
+++ b/tests/test_burgers.py
@@ -1,0 +1,20 @@
+import jax
+import jax.numpy as jnp
+
+from stde.config import EqnConfig
+from stde import equations
+
+
+def test_burgers_zero_residual():
+    cfg = EqnConfig(dim=1)
+    eqn = equations.Burgers
+
+    def u_fn(x, t):
+        return eqn.sol(x, t, cfg)
+
+    # sample a grid of points
+    x = jnp.linspace(-1, 1, 5).reshape(-1, 1)
+    t = jnp.linspace(0, cfg.T, 5).reshape(-1, 1)
+
+    res = jax.vmap(lambda x_, t_: eqn.res(x_, t_, u_fn, cfg))(x, t)
+    assert jnp.allclose(res, 0.0, atol=1e-5)


### PR DESCRIPTION
## Summary
- implement 1D Burgers' equation module
- register Burgers equation in EqnConfig
- document Burgers in README
- test analytic solution residual

## Testing
- `PYTHONPATH=$PWD pytest tests/test_burgers.py -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: Gradient only defined for scalar-output functions, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688259ebf9e08320b322ed132272490f