### PR TITLE
Log additional evaluation metrics

### DIFF
--- a/stde/equations.py
+++ b/stde/equations.py
@@ -1138,6 +1138,22 @@ KdV: Equation = Equation(
 )
 
 
+def KdV_mass(x: types.X, t: types.T, u_fn: Callable[[types.X, types.T], jax.Array], cfg: EqnConfig) -> jax.Array:
+  """Approximate conserved mass for KdV by Monte Carlo sampling."""
+  u_val = jax.vmap(u_fn)(x, t)
+  return jnp.mean(u_val)
+
+
+def KdV_energy(x: types.X, t: types.T, u_fn: Callable[[types.X, types.T], jax.Array], cfg: EqnConfig) -> jax.Array:
+  """Approximate conserved energy for KdV by Monte Carlo sampling."""
+  grad_fn = jax.vmap(jax.grad(lambda xx, tt: u_fn(xx, tt), argnums=0))
+  u_val = jax.vmap(u_fn)(x, t)
+  u_x = grad_fn(x, t)
+  energy_density = 0.5 * jnp.sum(u_x**2, axis=-1) - (u_val**3) / 6.0
+  return jnp.mean(energy_density)
+
+
+
 def KdV2d_res(
   xy: types.x_like,
   t: types.t_like,

--- a/stde/train.py
+++ b/stde/train.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import time
 from functools import partial
 from typing import Tuple
 
@@ -111,9 +112,10 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
       y_t_true_l2 = np_.linalg.norm(y_t_true)
 
     y_true_l1, y_true_l2 = [np_.linalg.norm(y_true, ord=ord) for ord in [1, 2]]
+    y_true_linf = float(np_.max(np_.abs(y_true)))
 
   elif eqn.offline_sol != "":
-    pass
+    y_true_linf = 1.
 
   @jax.jit
   def update(state: TrainingState) -> Tuple:
@@ -165,6 +167,7 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
 
   losses = []
   l1_rels, l2_rels, w1_t_rels = [], [], []
+  linf_rels, res_means, res_maxs = [], [], []
   l1_rel = l2_rel = w1_t_rel = 0.
 
   logger = logging.getLogger()
@@ -175,8 +178,12 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
   iters = tqdm(range(cfg.gd_cfg.epochs), file=tqdm_out)
 
   gpu_mems = [0.]
+  epoch_times = []
+  start_time = time.time()
   calc_w1 = eqn.time_dependent and cfg.model_cfg.compute_w1_loss
   for step in iters:
+
+    step_start = time.time()
 
     loss, state, aux = update(state)
 
@@ -188,7 +195,9 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
     if (step + 1) % cfg.test_cfg.eval_every == 0 or (get_mem and step == 100):
 
       if not eqn.is_traj:
-        l1_total, l2_total_sqr, w1_t_total_sqr = 0., 0., 0.
+        l1_total, l2_total_sqr, linf_val = 0., 0., 0.
+        res_sum, res_max = 0., 0.
+        w1_t_total_sqr = 0.
         for i in range(n_test_batches):
           l1, l2_sqr, w1_t_sqr = err_norms_jit(
             state.params, state.rng_key, x_tests[i], t_tests[i], y_trues[i],
@@ -198,13 +207,26 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
           l2_total_sqr += l2_sqr
           w1_t_total_sqr += w1_t_sqr
 
+          y_pred = jax.vmap(lambda x_, t_: model.apply.u(state.params, state.rng_key, x_, t_))(x_tests[i], t_tests[i])
+          err = jnp.abs(y_trues[i] - y_pred)
+          linf_val = max(linf_val, float(jnp.max(err)))
+          res_batch = jax.vmap(lambda x_, t_: eqn.res(x_, t_, lambda x1, t1: model.apply.u(state.params, state.rng_key, x1, t1), cfg.eqn_cfg))(x_tests[i], t_tests[i])
+          res_sum += float(jnp.mean(jnp.abs(res_batch)))
+          res_max = max(res_max, float(jnp.max(jnp.abs(res_batch))))
+
         l1_rel = float(l1_total / y_true_l1)
         l2_rel = float(l2_total_sqr**0.5 / y_true_l2)
+        linf_rel = float(linf_val / y_true_linf)
+        res_mean = float(res_sum / n_test_batches)
+        res_max_val = float(res_max)
         w1_t_rel = float(w1_t_total_sqr**0.5 / y_t_true_l2)
 
         l1_rels.append(l1_rel)
         l2_rels.append(l2_rel)
         w1_t_rels.append(w1_t_rel)
+        linf_rels.append(linf_rel)
+        res_means.append(res_mean)
+        res_maxs.append(res_max_val)
 
         desc_str = f"{l1_rel=:.2E} | {l2_rel=:.2E} | {loss=:.2E} | "
         desc_str += " | ".join(
@@ -234,7 +256,9 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
 
       if use_wandb:
         wandb.log(
-          dict(l1_rel=l1_rel, l2_rel=l2_rel, w1_t_rel=w1_t_rel), step=step
+          dict(l1_rel=l1_rel, l2_rel=l2_rel, linf_rel=linf_rel,
+               res_mean=res_mean, res_max=res_max_val,
+               w1_t_rel=w1_t_rel), step=step
         )
 
       if get_mem:
@@ -247,6 +271,8 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
 
     if step % cfg.test_cfg.save_every == 0:
       cfg.save_params(state.params, step)
+
+    epoch_times.append(time.time() - step_start)
 
   with open(absl_log.get_log_file_name(), 'r') as f:
     lines = f.readlines()
@@ -268,4 +294,33 @@ def train(cfg: Config, use_wandb: bool, run_id: int = 1, get_mem: bool = False):
       logging.warn(e)
       iter_per_s = float(lines[-4].strip().split(', ')[-1].split('it/s')[0])
 
-  return losses, l1_rels, l2_rels, iter_per_s, max(gpu_mems)
+  total_time = time.time() - start_time
+  time_per_epoch = sum(epoch_times) / len(epoch_times)
+
+  mass_err = energy_err = 0.0
+  if cfg.eqn_cfg.name == "KdV":
+    sample_x, sample_t, _, _, rng = sample_domain_fn(cfg.eqn_cfg.mc_batch_size, 0, rng)
+    t0 = jnp.zeros_like(sample_t)
+    tT = jnp.ones_like(sample_t) * cfg.eqn_cfg.T
+    u_fn = lambda x, t: model.apply.u(state.params, state.rng_key, x, t)
+    mass0 = eqns.KdV_mass(sample_x, t0, u_fn, cfg.eqn_cfg)
+    massT = eqns.KdV_mass(sample_x, tT, u_fn, cfg.eqn_cfg)
+    energy0 = eqns.KdV_energy(sample_x, t0, u_fn, cfg.eqn_cfg)
+    energyT = eqns.KdV_energy(sample_x, tT, u_fn, cfg.eqn_cfg)
+    mass_err = float(jnp.abs(massT - mass0))
+    energy_err = float(jnp.abs(energyT - energy0))
+
+  return dict(
+      losses=losses,
+      l1_rels=l1_rels,
+      l2_rels=l2_rels,
+      linf_rels=linf_rels,
+      res_means=res_means,
+      res_maxs=res_maxs,
+      iter_per_s=iter_per_s,
+      time_per_epoch=time_per_epoch,
+      total_time=total_time,
+      peak_gpu_mem=max(gpu_mems),
+      mass_error=mass_err,
+      energy_error=energy_err,
+  )

--- a/train_bimamba.py
+++ b/train_bimamba.py
@@ -5,6 +5,7 @@ import json
 import io
 import logging
 import pickle
+import time
 from functools import partial
 from typing import Callable, Tuple, Optional, get_args
 
@@ -643,7 +644,10 @@ def main():
     losses = []
     best_loss = float("inf")
     iters = tqdm(range(args.epochs), desc=f"training eqn {args.eqn_name}\n")
+    epoch_times = []
+    start_time = time.time()
     for step in iters:
+        step_start = time.time()
         state, train_loss, grads = train_step(state)
         train_loss_f = float(train_loss)
         losses.append(train_loss_f)
@@ -661,13 +665,15 @@ def main():
         )
 
         if step % args.eval_every == 0 or step == args.epochs - 1:
-            l1_rel, l2_rel = eval_model(mamba, state.params, eqn, eqn_cfg, test_seqs, test_truths, y_true_l1, y_true_l2, args)
+            l1_rel, l2_rel, linf_rel, res_mean, res_max, mass_err, energy_err = eval_model(
+                mamba, state.params, eqn, eqn_cfg, test_seqs, test_truths, y_true_l1, y_true_l2, args)
             grad_norm = float(jnp.sqrt(
                 sum(jnp.vdot(g, g) for g in jax.tree_util.tree_leaves(grads))
             ))
             desc_str = (
                 f"iter={step} | "
                 f"l1_rel={l1_rel:.2e} | l2_rel={l2_rel:.2e} | "
+                f"linf_rel={linf_rel:.2e} | res_mean={res_mean:.2e} | "
                 f"loss={train_loss:.2e} | grad_norm={grad_norm:.2e}"
             )
             # save desc_str to log file
@@ -677,6 +683,8 @@ def main():
             peak_mem = mem_stats['peak_bytes_in_use'] / 1024**2
             gpu_mems.append(peak_mem)
 
+        epoch_times.append(time.time() - step_start)
+
     # read iter/s from log file
     try:
         with open(log_file, "r") as f:
@@ -684,6 +692,9 @@ def main():
         iter_per_s = float(lines[-3].strip().split(', ')[-1].split('it/s')[0])
     except Exception:
         iter_per_s = 0.0
+
+    total_time = time.time() - start_time
+    time_per_epoch = sum(epoch_times) / len(epoch_times)
 
     # --- Plot training loss curve ---
     plt.plot(losses)
@@ -701,7 +712,7 @@ def main():
             best_params = pickle.load(f)
         state = state.replace(params=best_params)
     print("\n=== Final evaluation on test set ===")
-    l1_rel, l2_rel = eval_model(
+    l1_rel, l2_rel, linf_rel, res_mean, res_max, mass_err, energy_err = eval_model(
         mamba,
         state.params,
         eqn,
@@ -724,7 +735,14 @@ def main():
             {
                 "l1_rel": l1_rel,
                 "l2_rel": l2_rel,
+                "linf_rel": linf_rel,
+                "residual_mean": res_mean,
+                "residual_max": res_max,
+                "mass_error": mass_err,
+                "energy_error": energy_err,
                 "iter_per_s": iter_per_s,
+                "time_per_epoch": time_per_epoch,
+                "total_time": total_time,
                 "peak_gpu_mem": max(gpu_mems),
                 "num_params": num_params,
                 "final_loss": float(losses[-1]) if losses else 0.0,
@@ -959,28 +977,61 @@ def main():
 
 
 def eval_model(mamba, params, eqn, eqn_cfg, test_seqs, test_truths, y_true_l1, y_true_l2, args):
-    """Evaluate the model and return l1_rel and l2_rel."""
+    """Evaluate the model and return various error metrics."""
     if not eqn.is_traj:
-        l1_total, l2_total_sqr = 0.0, 0.0
+        l1_total, l2_total_sqr, linf_val = 0.0, 0.0, 0.0
+        res_sum, res_max = 0.0, 0.0
+        def u_fn(x, t):
+            xt = jnp.concatenate([x, t])
+            seq = jnp.broadcast_to(xt, (1, args.seq_len, xt.shape[0]))
+            out = mamba.apply({"params": params}, seq)
+            if out.ndim == 3:
+                out = out[0, -1]
+            return jnp.squeeze(out)
         for b in range(test_seqs.shape[0]):
             x_seq = test_seqs[b]
             y_true = test_truths[b]
             y_pred = mamba.apply({"params": params}, x_seq)
-            # drop trailing dim if present
             if y_pred.ndim == 3 and y_pred.shape[-1] == 1:
                 y_pred = y_pred.squeeze(-1)
             err = y_pred - y_true
             l1_total += jnp.sum(jnp.abs(err))
             l2_total_sqr += jnp.sum(err**2)
+            linf_val = max(linf_val, float(jnp.max(jnp.abs(err))))
+
+            x = x_seq[..., :args.spatial_dim].reshape(-1, args.spatial_dim)
+            t = x_seq[..., -1:].reshape(-1, 1)
+            res = jax.vmap(lambda xv, tv: eqn.res(xv, tv, u_fn, eqn_cfg))(x, t)
+            res_sum += float(jnp.mean(jnp.abs(res)))
+            res_max = max(res_max, float(jnp.max(jnp.abs(res))))
         l1_rel = float(l1_total / y_true_l1)
         l2_rel = float(jnp.sqrt(l2_total_sqr) / y_true_l2)
+        linf_rel = float(linf_val / float(jnp.max(jnp.abs(test_truths))))
+        res_mean = float(res_sum / test_seqs.shape[0])
+        res_max_val = float(res_max)
     else:
         xt_zero = jnp.zeros((1, args.seq_len, args.spatial_dim + 1))
         y_pred = mamba.apply({"params": params}, xt_zero)[0, 0]
         y_true = eqn.sol(jnp.zeros((args.spatial_dim,)), jnp.zeros((1,)), eqn_cfg)
         l1_rel = float(jnp.abs(y_pred - y_true) / jnp.abs(y_true))
         l2_rel = l1_rel
-    return l1_rel, l2_rel
+        linf_rel = l1_rel
+        res_mean = res_max_val = 0.0
+
+    mass_err = energy_err = 0.0
+    if eqn_cfg.name == "KdV":
+        rng = jax.random.PRNGKey(0)
+        x_m, t_m, _, _, _ = sample_domain_fn(eqn_cfg.mc_batch_size, 0, rng)
+        t0 = jnp.zeros_like(t_m)
+        tT = jnp.ones_like(t_m) * eqn_cfg.T
+        mass0 = eqns.KdV_mass(x_m, t0, u_fn, eqn_cfg)
+        massT = eqns.KdV_mass(x_m, tT, u_fn, eqn_cfg)
+        energy0 = eqns.KdV_energy(x_m, t0, u_fn, eqn_cfg)
+        energyT = eqns.KdV_energy(x_m, tT, u_fn, eqn_cfg)
+        mass_err = float(jnp.abs(massT - mass0))
+        energy_err = float(jnp.abs(energyT - energy0))
+
+    return l1_rel, l2_rel, linf_rel, res_mean, res_max_val, mass_err, energy_err
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- measure mass and energy for KdV
- track residual and L∞ metrics during training
- record training time and GPU memory
- include new metrics in BiMamba training output

## Testing
- `pytest -q` *(fails: AttributeError and other exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68825a28848083209846ef8f58537025