### PR TITLE
Fix training script paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ To run the amortized gradient-enhanced PINN described in Appendix I.4.2, change 
 This repository provides utilities for physics-informed neural network (PINN)
 experiments built around stochastic Taylor derivative estimators (STDE).  The
 core functionality lives inside the `stde/` package while scripts such as
-`train_bimamba.py` offer ready-to-run training setups.
+`stde/train.py` offer ready-to-run training setups.
 
-`train_bimamba.py` trains a PINN composed of bidirectional MAMBA blocks. Key
+`stde/train.py` trains a PINN composed of bidirectional MAMBA blocks. Key
 methods include:
 
 - **`sample_domain_seq_fn`** – samples sequences of domain points via the

--- a/scripts/insep.sh
+++ b/scripts/insep.sh
@@ -1,4 +1,4 @@
-python main.py \
+python -m stde.train \
     --config.eqn_cfg.batch_size 100 \
     --config.eqn_cfg.batch_size_boundary 100 \
     --config.eqn_cfg.enforce_boundary=True \

--- a/scripts/run_bimamba_all.sh
+++ b/scripts/run_bimamba_all.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# Run train_bimamba.py for every PDE defined in EqnConfig.
+# Run stde/train.py for every PDE defined in EqnConfig.
 # For each PDE we run once with sparse_stde and once with backward-mode AD
 # (stacked Hessian calculation).  Logs are written to logs/ and runs continue
 # even if an error occurs.
 
 set -u
 
-# Main arguments for train_bimamba.py (edit as needed)
+# Main arguments for stde/train.py (edit as needed)
 EPOCHS=10000
 EVAL_EVERY=5000
 LR=1e-4
@@ -54,7 +54,7 @@ PY
             LOG_FILE="logs/${PDE}_${METHOD}_d${DIM}.log"
             RUN_NAME="${PDE}_${METHOD}_d${DIM}"
             echo "Running $PDE with $METHOD and dim $DIM" | tee -a "$LOG_FILE"
-            if python train_bimamba.py \
+            if python -m stde.train \
                 --eqn_name "$PDE" \
                 --spatial_dim "$DIM" \
                 --hess_diag_method "$METHOD" \

--- a/scripts/semilinear_parabolic.sh
+++ b/scripts/semilinear_parabolic.sh
@@ -1,4 +1,4 @@
-python main.py \
+python -m stde.train \
     --config.eqn_cfg.unbiased=False \
     --config.eqn_cfg.discretize_time=False \
     --config.eqn_cfg.batch_size 2000 \


### PR DESCRIPTION
## Summary
- update README to reference `stde/train.py`
- fix `run_bimamba_all.sh` to call the new training module
- update `insep.sh` and `semilinear_parabolic.sh` to use `stde.train`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e33ae5e483209c8addbb8c894009