### PR TITLE
Add explicit PRNG key threading

### DIFF
--- a/stde/equations.py
+++ b/stde/equations.py
@@ -77,6 +77,7 @@ def HJB_LIN_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   r"""Returns the residual to the HJB-LIN equation, which is the
   LHS-RHS of the following equation:
@@ -96,7 +97,7 @@ def HJB_LIN_res(
     t = xt[cfg.dim:]
     return u(x, t)
 
-  _, _, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt)
+  _, _, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt, key=key)
 
   u_xx: types.x_like = u_d2[:-1]
   u_x: types.x_like = u_d1[:-1]
@@ -151,6 +152,7 @@ def HJB_LQG_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   r"""Returns the residual to the HJB-LQG equation, which is the
   LHS of the following equation:
@@ -170,7 +172,7 @@ def HJB_LQG_res(
     t = xt[cfg.dim:]
     return u(x, t)
 
-  _, _, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt)
+  _, _, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt, key=key)
 
   u_xx: types.x_like = u_d2[:-1]
   u_x: types.x_like = u_d1[:-1]
@@ -247,6 +249,7 @@ def BSB_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   assert cfg.hess_diag_method != "dense_stde"
   xt: Float[Array, "xt_dim"] = jnp.concatenate([x, t], axis=-1)
@@ -257,7 +260,7 @@ def BSB_res(
     return u(x, t)
 
   u_: Float[Array, "1"]
-  idx_set, u_, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt)
+  idx_set, u_, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt, key=key)
   u_xx: types.x_like = u_d2[:-1]
   u_x: types.x_like = u_d1[:-1]
   u_t: types.t_like = u_d1[-1:]
@@ -301,6 +304,7 @@ def Wave_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   r"""
   .. math::
@@ -315,7 +319,7 @@ def Wave_res(
     t = xt[cfg.dim:]
     return u(x, t)
 
-  _, _, _, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt)
+  _, _, _, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt, key=key)
 
   u_xx: types.x_like = u_d2[:-1]
   u_tt: types.t_like = u_d2[-1:]
@@ -430,13 +434,15 @@ def get_inhomo_res_fn_from_sol(op_fn: Callable, sol_fn: Callable):
     t: types.t_like,
     u: types.U,
     cfg: EqnConfig,
+    key: jax.Array,
   ) -> Float[Array, "xt_dim"]:
     r"""
     .. math::
     L u(x) = g(x)
     """
-    Lu = op_fn(x, t, u, cfg)
-    g = op_fn(x, t, partial(sol_fn, cfg=cfg), cfg)
+    key_op1, key_op2 = jax.random.split(key)
+    Lu = op_fn(x, t, u, cfg, key=key_op1)
+    g = op_fn(x, t, partial(sol_fn, cfg=cfg), cfg, key=key_op2)
     return Lu - g
 
   return res_fn
@@ -456,17 +462,20 @@ def get_inhomo_res_fn(
     t: types.t_like,
     u: types.U,
     cfg: EqnConfig,
+    key: jax.Array,
   ) -> Float[Array, "xt_dim"]:
     r"""
     .. math::
     L u(x) = g(x)
     """
     if with_g:
-      Lu, Lu_grad, idx_set_g = op_fn(x, t, u, cfg)
+      key_op, key = jax.random.split(key)
+      Lu, Lu_grad, idx_set_g = op_fn(x, t, u, cfg, key=key_op)
       g, g_grad = jax.value_and_grad(inhomo_fn)(x, cfg)
       return Lu - g, Lu_grad - g_grad[idx_set_g]
     else:
-      Lu = op_fn(x, t, u, cfg)
+      key_op, key = jax.random.split(key)
+      Lu = op_fn(x, t, u, cfg, key=key_op)
       g = inhomo_fn(x, cfg)
       return Lu - g
 
@@ -478,9 +487,10 @@ def Poisson_op(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   u_xx: types.x_like
-  _, _, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+  _, _, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key)
   return u_xx.sum()
 
 
@@ -506,6 +516,7 @@ def NLS_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   """Residual of the 1D cubic Nonlinear Schrödinger equation.
 
@@ -614,6 +625,7 @@ def Burgers_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   """Residual for the 1D viscous Burgers' equation."""
   xt = jnp.concatenate([x, t], axis=-1)
@@ -623,7 +635,7 @@ def Burgers_res(
     t_ = xt[cfg.dim :]
     return jnp.squeeze(u(x_, t_))
 
-  _, u_val, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt)
+  _, u_val, u_d1, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt, key=key)
   u_x = u_d1[:-1]
   u_t = u_d1[-1:]
   u_xx = u_d2[:-1]
@@ -817,6 +829,7 @@ def AllenCahn_op(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   r"""
   .. math::
@@ -824,7 +837,7 @@ def AllenCahn_op(
   """
   u_: Float[Array, "1"]
   u_xx: types.x_like
-  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key)
   return u_xx.sum() + u_ - u_**3
 
 
@@ -852,9 +865,11 @@ def AllenCahnTwobodyG_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ):
   dim = cfg.dim
-  idx_set_i = get_sdgd_idx_set(cfg)
+  key_i, key = jax.random.split(key)
+  idx_set_i = get_sdgd_idx_set(cfg, key=key_i)
 
   u_partial = partial(u, t=t)
 
@@ -877,7 +892,8 @@ def AllenCahnTwobodyG_res(
     u_res_grad_j = u_iij + u_j - 3 * u_**2 * u_j - g_x[j]
     return u_ii, u_res_grad_j
 
-  idx_set_j = get_sdgd_idx_set(cfg)
+  key_j, key_hess = jax.random.split(key)
+  idx_set_j = get_sdgd_idx_set(cfg, key=key_j)
 
   if cfg.hess_diag_method == "sparse_stde":
     u_ii, g_res = jax.vmap(res_j_fn)(idx_set_i, idx_set_j)
@@ -885,7 +901,7 @@ def AllenCahnTwobodyG_res(
     u_lapl = (u_ii * dim / cfg.rand_batch_size).sum()
     res = u_lapl + u_ - u_**3 - g
   else:
-    _, u_, u_x, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+    _, u_, u_x, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key_hess)
     res = u_xx.sum() + u_ - u_**3 - g
 
     def res_j_baseline_fn(i, j):
@@ -919,9 +935,11 @@ def SineGordonTwobodyG_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ):
   dim = cfg.dim
-  idx_set_i = get_sdgd_idx_set(cfg)
+  key_i, key = jax.random.split(key)
+  idx_set_i = get_sdgd_idx_set(cfg, key=key_i)
 
   u_partial = partial(u, t=t)
 
@@ -944,7 +962,8 @@ def SineGordonTwobodyG_res(
     u_res_grad_j = u_iij + jnp.cos(u_) * u_j - g_x[j]
     return u_ii, u_res_grad_j
 
-  idx_set_j = get_sdgd_idx_set(cfg)
+  key_j, key_hess = jax.random.split(key)
+  idx_set_j = get_sdgd_idx_set(cfg, key=key_j)
 
   if cfg.hess_diag_method == "sparse_stde":
     u_ii, g_res = jax.vmap(res_j_fn)(idx_set_i, idx_set_j)
@@ -952,7 +971,7 @@ def SineGordonTwobodyG_res(
     u_lapl = (u_ii * dim / cfg.rand_batch_size).sum()
     res = u_lapl + jnp.sin(u_) - g
   else:
-    _, u_, u_x, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+    _, u_, u_x, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key_hess)
     res = u_xx.sum() + jnp.sin(u_) - g
 
     def res_j_baseline_fn(i, j):
@@ -984,9 +1003,11 @@ def PoissonTwobodyG_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   dim = cfg.dim
-  idx_set_i = get_sdgd_idx_set(cfg)
+  key_i, key = jax.random.split(key)
+  idx_set_i = get_sdgd_idx_set(cfg, key=key_i)
 
   u_partial = partial(u, t=t)
 
@@ -1009,7 +1030,8 @@ def PoissonTwobodyG_res(
     u_res_grad_j = u_iij - g_x[j]
     return u_ii, u_res_grad_j
 
-  idx_set_j = get_sdgd_idx_set(cfg)
+  key_j, key_hess = jax.random.split(key)
+  idx_set_j = get_sdgd_idx_set(cfg, key=key_j)
 
   if cfg.hess_diag_method == "sparse_stde":
     u_ii, g_res = jax.vmap(res_j_fn)(idx_set_i, idx_set_j)
@@ -1017,7 +1039,7 @@ def PoissonTwobodyG_res(
     u_lapl = (u_ii * dim / cfg.rand_batch_size).sum()
     res = u_lapl - g
   else:
-    _, u_, u_x, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+    _, u_, u_x, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key_hess)
     res = u_xx.sum() - g
 
     def res_j_baseline_fn(i, j):
@@ -1072,9 +1094,11 @@ def get_dt_res_fn(op_fn: Callable) -> Callable:
     t: types.t_like,
     u: types.U,
     cfg: EqnConfig,
+    key: jax.Array,
   ) -> Float[Array, "1"]:
     u_t = jax.grad(u, argnums=1)(x, t)
-    res = u_t - op_fn(x, t, u, cfg)
+    key_op, key = jax.random.split(key)
+    res = u_t - op_fn(x, t, u, cfg, key=key_op)
     return jnp.squeeze(res)
 
   return res_fn
@@ -1085,6 +1109,7 @@ def SineGordon_op(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "xt_dim"]:
   r"""
   .. math::
@@ -1092,7 +1117,7 @@ def SineGordon_op(
   """
   u_: Float[Array, "1"]
   u_xx: types.x_like
-  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key)
   return u_xx.sum() + jnp.sin(u_)
 
 
@@ -1118,6 +1143,7 @@ def SineGordon_op_G(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "xt_dim"]:
   r"""
   .. math::
@@ -1125,7 +1151,7 @@ def SineGordon_op_G(
   """
   u_: Float[Array, "1"]
   u_xx: types.x_like
-  idx_set, u_, u_y, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+  idx_set, u_, u_y, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key)
 
   # compute gPINN part
 
@@ -1143,9 +1169,9 @@ def SineGordon_op_G(
   )[1][6] / 105
 
   # sample gPINN dim
-  key = hk.next_rng_key()
+  key, key_g = jax.random.split(key)
   idx_set_g = jax.random.choice(
-    key, cfg.dim, shape=(cfg.n_gpinn_vec,), replace=False
+    key_g, cfg.dim, shape=(cfg.n_gpinn_vec,), replace=False
   )
 
   u_xxy = jax.vmap(
@@ -1194,6 +1220,7 @@ def KdV_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   r"""
   .. math::
@@ -1208,7 +1235,7 @@ def KdV_res(
     t = xt[cfg.dim:]
     return u(x, t)
 
-  _, _, _, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt)
+  _, _, _, u_d2 = hess_diag(u_xt, cfg, with_time=True)(xt, key=key)
 
   u_xx: types.x_like = u_d2[:-1]
   u_tt: types.t_like = u_d2[-1:]
@@ -1286,6 +1313,7 @@ def KdV2d_res(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   r"""
   .. math::
@@ -1317,7 +1345,8 @@ def KdV2d_res(
     u_xy, _, u_xxxy = jet.jet(
       lambda x_: u_y_fn(x_, y, t), (x,), series=((1.0, 0.0, 0.0),)
     )[1]
-    _, _, u_d1, u_d2 = hess_diag(u, cfg, argnums=0)(xy, t)
+    key, key_hd = jax.random.split(key)
+    _, _, u_d1, u_d2 = hess_diag(u, cfg, argnums=0)(xy, t, key=key_hd)
 
     u_x: types.x_like = u_d1[:-1]
     u_y: types.x_like = u_d1[-1:]
@@ -1390,7 +1419,8 @@ def KdV2d_res(
     u_x, u_xx, _, u_xxxx = jet.jet(
       lambda x_: u_fn(x_, y, t), (x,), series=((1.0, 0.0, 0.0, 0.0),)
     )[1]
-    u_, _, _, u_d2 = hess_diag(u, cfg, argnums=0)(xy, t)
+    key, key_hd = jax.random.split(key)
+    u_, _, _, u_d2 = hess_diag(u, cfg, argnums=0)(xy, t, key=key_hd)
     u_yy: types.x_like = u_d2[-1:]
 
   elif case == 6:
@@ -1404,7 +1434,8 @@ def KdV2d_res(
     u_x, u_xx, _, u_xxxx = jet.jet(
       lambda x_: u_fn(x_, y, t), (x,), series=((1.0, 0.0, 0.0, 0.0),)
     )[1]
-    u_, _, _, u_d2 = hess_diag(u, cfg, argnums=0)(xy, t)
+    key, key_hd = jax.random.split(key)
+    u_, _, _, u_d2 = hess_diag(u, cfg, argnums=0)(xy, t, key=key_hd)
     u_yy: types.x_like = u_d2[-1:]
 
   if True:  # KdV
@@ -1705,9 +1736,11 @@ def get_traj_res_fn(op_fn: Callable) -> Callable:
     t: Float[Array, "n_t 1"],
     u: types.U,
     cfg: EqnConfig,
+    key: jax.Array,
   ):
     u_t: types.t_like = jax.grad(u, argnums=1)(x, t)
-    res = u_t + op_fn(x, t, u, cfg)
+    key_op, _ = jax.random.split(key)
+    res = u_t + op_fn(x, t, u, cfg, key=key_op)
     return res
 
   return res_fn
@@ -1762,6 +1795,7 @@ def SemilinearHeat_op(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "1"]:
   r"""
   .. math::
@@ -1769,7 +1803,7 @@ def SemilinearHeat_op(
   """
   u_: Float[Array, "1"]
   u_xx: types.x_like
-  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key)
   u_sqr = u_**2
   return u_xx.sum() + (1 - u_sqr) / (1 + u_sqr)
 
@@ -1857,6 +1891,7 @@ def SineGordonTime_op(
   t: types.t_like,
   u: types.U,
   cfg: EqnConfig,
+  key: jax.Array,
 ) -> Float[Array, "xt_dim"]:
   r"""
   .. math::
@@ -1864,7 +1899,7 @@ def SineGordonTime_op(
   """
   u_: Float[Array, "1"]
   u_xx: types.x_like
-  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t)
+  _, u_, _, u_xx = hess_diag(u, cfg, argnums=0)(x, t, key=key)
   return u_xx.sum() + cfg.dim * jnp.sin(u_ / cfg.dim)
 
 
@@ -1888,6 +1923,7 @@ def pinn_loss_fn(
   u: types.U,
   cfg: EqnConfig,
   eqn: Equation,
+  key: jax.Array,
 ):
   r"""Return the PINN loss for of an equation (represented by eqn). The domain
   residual is given by the eqn.res function, and the boundary condition
@@ -1901,16 +1937,18 @@ def pinn_loss_fn(
   domain_res: Float[types.NPArray, "*batch 1"]
   g_res: Float[types.NPArray, "*batch x_dim"]
 
-  res_fn = lambda x_, t_: eqn.res(x_, t_, u, cfg)
+  res_fn = lambda x_, t_, k_: eqn.res(x_, t_, u, cfg, k_)
+  keys = jax.random.split(key, x.shape[0]) if x is not None else jnp.array([])
 
   if eqn.with_g:
-    domain_res, g_res = jax.vmap(res_fn)(x, t)
+    domain_res, g_res = jax.vmap(res_fn)(x, t, keys)
   else:
-    domain_res = jax.vmap(res_fn)(x, t)
+    domain_res = jax.vmap(res_fn)(x, t, keys)
 
   if cfg.unbiased:
     # NOTE: create a separate independent sample set
-    domain_res_2 = jax.vmap(res_fn)(x, t)
+    keys2 = jax.random.split(key, x.shape[0])
+    domain_res_2 = jax.vmap(res_fn)(x, t, keys2)
     domain_loss = jnp.mean(jax.lax.stop_gradient(domain_res) * domain_res_2)
 
   else:  # biased

--- a/stde/operators.py
+++ b/stde/operators.py
@@ -1,6 +1,4 @@
 from typing import Callable, Sequence, Tuple
-
-import haiku as hk
 import jax
 import jax.numpy as jnp
 # from folx import forward_laplacian
@@ -20,9 +18,9 @@ def partial_i(fn: Callable, i: int, *args):
   return lambda x: fn(*[arg if arg is not None else x for arg in p_args])
 
 
-def get_sdgd_idx_set(cfg: EqnConfig) -> Array:
+def get_sdgd_idx_set(cfg: EqnConfig, *, key: jax.Array) -> Array:
+  """Return a set of randomly chosen dimension indices."""
   if cfg.rand_batch_size != 0:
-    key = hk.next_rng_key()
     idx_set = jax.random.choice(
       key, cfg.dim, shape=(cfg.rand_batch_size,), replace=False
     )
@@ -39,6 +37,8 @@ def hvp(f, x, v):
 def get_hutchinson_random_vec(
   idx_set: Array,
   cfg: EqnConfig,
+  *,
+  key: jax.Array,
   with_time: bool = False,
 ) -> Float[Array, "x_dim"]:
   """Return a random vector on sdgd sampled dimensions, with Rademacher
@@ -46,14 +46,13 @@ def get_hutchinson_random_vec(
 
   If with_time, add a one-hot time dimension at the end.
   """
-  key = hk.next_rng_key()
   d = cfg.rand_batch_size or cfg.dim
   if cfg.stde_dist == "normal":
     rand_vec = jax.random.normal(key, shape=(cfg.rand_batch_size, d))
   elif cfg.stde_dist == "rademacher":
     rand_vec = 2 * (
-      jax.random
-      .randint(key, shape=(cfg.rand_batch_size, d), minval=0, maxval=2) - 0.5
+      jax.random.randint(key, shape=(cfg.rand_batch_size, d), minval=0, maxval=2)
+      - 0.5
     )
   else:
     raise ValueError
@@ -79,7 +78,7 @@ def hte(
   is non‑zero.  The estimation relies on JAX's ``jet`` API to obtain
   Hessian‑vector products.
 
-  Returns a callable ``f_trace(*xs)`` that outputs
+  Returns a callable ``f_trace(*xs, key)`` that outputs
 
   ``idx_set`` : the sampled indices used for the estimator.
   ``f_val``   : the scalar function value.
@@ -87,7 +86,8 @@ def hte(
   """
 
   def fn_trace(
-    *xs: Sequence[Float[types.NPArray, "xi_dim"]]
+    *xs: Sequence[Float[types.NPArray, "xi_dim"]],
+    key: jax.Array,
   ) -> Tuple[
     Integer[Array, "xi_dim"],
     Float[Array, "1"],
@@ -101,11 +101,12 @@ def hte(
     # Fix all other arguments so that ``f_partial`` depends only on ``x_i``.
     f_partial = partial_i(fn, argnums, *xs)
 
+    key_idx, key_vec = jax.random.split(key)
     # Randomly select a subset of coordinates for the Hutchinson estimator.
-    idx_set = get_sdgd_idx_set(cfg)
+    idx_set = get_sdgd_idx_set(cfg, key=key_idx)
 
     # Draw random vectors supported on ``idx_set``.
-    rand_sub_vec = get_hutchinson_random_vec(idx_set, cfg)
+    rand_sub_vec = get_hutchinson_random_vec(idx_set, cfg, key=key_vec)
 
     # Build a second-order Taylor expansion using ``jet`` to obtain
     # Hessian-vector products for each random vector ``v``.
@@ -151,7 +152,8 @@ def hess_diag(
   """
 
   def fn_hess_diag(
-    *xs: Sequence[Float[types.NPArray, "xi_dim"]]
+    *xs: Sequence[Float[types.NPArray, "xi_dim"]],
+    key: jax.Array,
   ) -> Tuple[
     Integer[Array, "xi_dim"],
     Float[Array, "1"],
@@ -165,8 +167,9 @@ def hess_diag(
 
     # create a partial function in which only x_i is a variable
     f_partial = partial_i(fn, argnums, *xs)
+    key_idx, key_vec = jax.random.split(key)
     # indices of x_i along which the hessian diagonal is computed
-    idx_set = get_sdgd_idx_set(cfg)
+    idx_set = get_sdgd_idx_set(cfg, key=key_idx)
 
     if cfg.hess_diag_method == "folx":
       # the folx package provides a forward-mode Laplacian operator
@@ -198,7 +201,7 @@ def hess_diag(
       )
 
       # generate random vectors on the sampled subset of dimensions
-      rand_sub_vec = get_hutchinson_random_vec(idx_set, cfg, with_time)
+      rand_sub_vec = get_hutchinson_random_vec(idx_set, cfg, key=key_vec, with_time=with_time)
 
       # evaluate the function and its Hessian-vector products
       f_vals, (_, hvps) = jax.vmap(taylor_2)(rand_sub_vec)

--- a/stde/train.py
+++ b/stde/train.py
@@ -407,7 +407,7 @@ if eqn.time_dependent:
         xt[..., : args.spatial_dim], xt[..., args.spatial_dim :], eqn_cfg
     )
 
-    def residual_fn(xt, u_fn: Callable) -> Float[Array, "xt_dim"]:
+    def residual_fn(xt, u_fn: Callable, key: jax.Array) -> Float[Array, "xt_dim"]:
         x_part = xt[..., : args.spatial_dim]
         t_part = xt[..., args.spatial_dim :]
         res = eqn.res(
@@ -415,6 +415,7 @@ if eqn.time_dependent:
             t_part,
             lambda xi, ti: u_fn(jnp.concatenate([xi, ti], axis=-1)),
             eqn_cfg,
+            key,
         )
         if isinstance(res, tuple):
             res = res[0]
@@ -422,8 +423,8 @@ if eqn.time_dependent:
 else:
     sol_fn = lambda x: eqn.sol(x, None, eqn_cfg)
 
-    def residual_fn(x, u_fn: Callable) -> Float[Array, "xt_dim"]:
-        res = eqn.res(x, None, lambda xi, _t: u_fn(xi), eqn_cfg)
+    def residual_fn(x, u_fn: Callable, key: jax.Array) -> Float[Array, "xt_dim"]:
+        res = eqn.res(x, None, lambda xi, _t: u_fn(xi), eqn_cfg, key)
         if isinstance(res, tuple):
             res = res[0]
         return res
@@ -552,7 +553,7 @@ def main():
                 def one_step_res(l, xt_l, key):
                     def u_fn(xt_i):
                         return y_at_l(xt_i, l, full_seq)
-                    res_val = residual_fn(xt_l, u_fn)
+                    res_val = residual_fn(xt_l, u_fn, key)
                     return res_val, key
                 keys = jax.random.split(key, L)
                 resids, _ = jax.vmap(one_step_res, in_axes=(0, 0, 0), out_axes=(0, 0))(
@@ -1037,7 +1038,8 @@ def eval_model(mamba, params, eqn, eqn_cfg, test_seqs, test_truths, y_true_l1, y
 
             x = x_seq[..., :args.spatial_dim].reshape(-1, args.spatial_dim)
             t = x_seq[..., -1:].reshape(-1, 1)
-            res = jax.vmap(lambda xv, tv: eqn.res(xv, tv, u_fn, eqn_cfg))(x, t)
+            keys = jax.random.split(jax.random.PRNGKey(0), x.shape[0])
+            res = jax.vmap(lambda xv, tv, k: eqn.res(xv, tv, u_fn, eqn_cfg, k))(x, t, keys)
             res_sum += float(jnp.mean(jnp.abs(res)))
             res_max = max(res_max, float(jnp.max(jnp.abs(res))))
         l1_rel = float(l1_total / y_true_l1)

--- a/tests/test_burgers.py
+++ b/tests/test_burgers.py
@@ -16,5 +16,6 @@ def test_burgers_zero_residual():
     x = jnp.linspace(-1, 1, 5).reshape(-1, 1)
     t = jnp.linspace(0, cfg.T, 5).reshape(-1, 1)
 
-    res = jax.vmap(lambda x_, t_: eqn.res(x_, t_, u_fn, cfg))(x, t)
+    keys = jax.random.split(jax.random.PRNGKey(0), x.shape[0])
+    res = jax.vmap(lambda x_, t_, k: eqn.res(x_, t_, u_fn, cfg, k))(x, t, keys)
     assert jnp.allclose(res, 0.0, atol=1e-5)

--- a/tests/test_nls.py
+++ b/tests/test_nls.py
@@ -15,7 +15,7 @@ def test_nls_shapes_and_residual():
     assert u_val.shape[0] == 3
 
     u_fn = lambda x_, t_: equations.NLS.sol(x_[None], t_[None], cfg)
-    res = equations.NLS.res(x[0], t[0], u_fn, cfg)
+    res = equations.NLS.res(x[0], t[0], u_fn, cfg, jax.random.PRNGKey(0))
     assert jnp.allclose(res, 0.0, atol=1e-5)
 
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -14,14 +14,16 @@ from stde.operators import get_hutchinson_random_vec, get_sdgd_idx_set
 
 def test_get_hutchinson_random_vec_shapes(monkeypatch):
     cfg = EqnConfig(dim=5, rand_batch_size=3)
-    rng_seq = hk.PRNGSequence(0)
-    monkeypatch.setattr(hk, 'next_rng_key', lambda: next(rng_seq))
+    key = jax.random.PRNGKey(0)
 
-    idx_set = get_sdgd_idx_set(cfg)
-    vec = get_hutchinson_random_vec(idx_set, cfg)
+    key_idx, key = jax.random.split(key)
+    idx_set = get_sdgd_idx_set(cfg, key=key_idx)
+    key_vec, key = jax.random.split(key)
+    vec = get_hutchinson_random_vec(idx_set, cfg, key=key_vec)
     assert vec.shape == (cfg.rand_batch_size, cfg.dim)
 
-    vec_time = get_hutchinson_random_vec(idx_set, cfg, with_time=True)
+    key_time, _ = jax.random.split(key)
+    vec_time = get_hutchinson_random_vec(idx_set, cfg, key=key_time, with_time=True)
     assert vec_time.shape == (cfg.rand_batch_size + 1, cfg.dim + 1)
     assert jnp.all(vec_time[-1] == jnp.eye(cfg.dim + 1)[-1])
 


### PR DESCRIPTION
## Summary
- accept PRNG keys in stochastic operator helpers
- pass keys through `hess_diag`/`hte` and all equation residuals
- update training loop and tests for new interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e7af329c8320931b680af2d21bbe